### PR TITLE
Add internal NullScope class

### DIFF
--- a/csharp-visualstudio/Functions.Tests/Functions.Tests.csproj
+++ b/csharp-visualstudio/Functions.Tests/Functions.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/csharp-visualstudio/Functions.Tests/ListLogger.cs
+++ b/csharp-visualstudio/Functions.Tests/ListLogger.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Functions.Tests
 {

--- a/csharp-visualstudio/Functions.Tests/NullScope.cs
+++ b/csharp-visualstudio/Functions.Tests/NullScope.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Functions.Tests
+{
+    public class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new NullScope();
+
+        private NullScope() { }
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Removes reference to Microsoft.Extensions.Logging.Abstractions in favor of a local NullScope stub for testing. Resolves [a customer doc issue](https://github.com/MicrosoftDocs/azure-docs/issues/21130#issuecomment-460701146).